### PR TITLE
Add support for a custom obfuscation character

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ You can optionally pass a custom character as the second argument. This can also
 
 Examples:
 
-- `obfuscate('awesometown@gmail.com', '*') //produces 'a**********@g****.com'
-- `obfuscate('awesometown@gmail.com', 'ha') //produces 'ahahahahahahahahahaha@ghahahaha.com'
-- `obfuscate('awesometown@gmail.com', '🤔') //produces 'a🤔🤔🤔🤔🤔🤔🤔🤔🤔🤔@g🤔🤔🤔🤔.com'
+- `obfuscate('awesometown@gmail.com', '*') //produces 'a**********@g****.com'`
+- `obfuscate('awesometown@gmail.com', 'ha') //produces 'ahahahahahahahahahaha@ghahahaha.com'`
+- `obfuscate('awesometown@gmail.com', '🤔') //produces 'a🤔🤔🤔🤔🤔🤔🤔🤔🤔🤔@g🤔🤔🤔🤔.com'`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ should produce:
 
 `axxxxxxxxxx@gxxxx.com`
 
+## Custom obfuscation character
+
+You can optionally pass a custom character as the second argument. This can also be a longer string or emoji.
+
+Examples:
+
+- `obfuscate('awesometown@gmail.com', '*') //produces 'a**********@g****.com'
+- `obfuscate('awesometown@gmail.com', 'ha') //produces 'ahahahahahahahahahaha@ghahahaha.com'
+- `obfuscate('awesometown@gmail.com', '🤔') //produces 'a🤔🤔🤔🤔🤔🤔🤔🤔🤔🤔@g🤔🤔🤔🤔.com'
+
 ## License
 
 MIT

--- a/lib/email-obfuscator.js
+++ b/lib/email-obfuscator.js
@@ -1,7 +1,10 @@
 var addrs = require("email-addresses");
 
-function obfuscatePart(part) {
-
+function obfuscatePart(part, obfuscationCharacter) {
+	if(!obfuscationCharacter || !obfuscationCharacter.length){
+		obfuscationCharacter = 'x';
+	}
+	
 	var obfuscatedPart = '',
 		expose = true,
 		i,
@@ -20,7 +23,7 @@ function obfuscatePart(part) {
 
 		} else if (isAlphaNumeric) {
 
-			obfuscatedPart += 'x';
+			obfuscatedPart += obfuscationCharacter;
 
 		} else {
 
@@ -35,8 +38,7 @@ function obfuscatePart(part) {
 
 }
 
-function obfuscate(emailAddress) {
-
+function obfuscate(emailAddress, obfuscationCharacter) {
 	var obfuscatedAddress = '',
 		parsedAddress,
 		local,
@@ -56,14 +58,14 @@ function obfuscate(emailAddress) {
 		if (domainParts.length > 1) {
 
 			tld = domainParts.pop();
-			obfuscatedDomain = obfuscatePart(domainParts.join('.')) + '.' + tld;
+			obfuscatedDomain = obfuscatePart(domainParts.join('.'), obfuscationCharacter) + '.' + tld;
 
 		} else {
 			obfuscatedDomain = domain;
 		}
 
 
-		obfuscatedAddress += obfuscatePart(local) + '@' + obfuscatedDomain;
+		obfuscatedAddress += obfuscatePart(local, obfuscationCharacter) + '@' + obfuscatedDomain;
 
 		return obfuscatedAddress;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "email-obfuscator",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Obfuscates e-mail addresses with x's (e.g. awesometown@gmail.com becomes axxxxxxxxxx@gxxxx.com)",
   "main": "lib/email-obfuscator.js",
   "directories": {


### PR DESCRIPTION
Hi there @bertrandom, we just added this package to a project at www.lesalon.com, great job!

I needed the obfuscation to be * instead of x, and instead of doing a simple string replace (which would * out the first character of any email beginning with x) I modified this project to support a custom character or string in a graceful way.

I've bumped the version to 0.02 and updated the README.

Hopefully you can merge this in and update npm!